### PR TITLE
Adds a keycloak container configured with our theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,9 @@ target/
 .ipynb_checkpoints
 *.ipynb
 
-# Heroku/Foreman
+# Heroku/Foreman/direnv
 .env
+.envrc
 
 # webpack
 static/bundles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
         context: ./keycloak
         args:
           KEYCLOAK_THEME_GIT_REF: ${KEYCLOAK_THEME_GIT_REF:-main}
-      command: start-dev
+      command: start-dev --features=preview --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false
       environment:
         DB_VENDOR: POSTGRES
         DB_ADDR: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-environment:
   CELERY_TASK_ALWAYS_EAGER: 'False'
   DATABASE_URL: postgres://postgres@db:5432/postgres
   DB_DISABLE_SSL: 'True'
-  DEBUG: 'False'
+  DEBUG: ${DEBUG:-False}
   DOCKER_HOST: ${DOCKER_HOST:-missing}
   ELASTICSEARCH_URL: elastic:9200
   MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET: test-hmac-secret
@@ -21,6 +21,8 @@ services:
     image: postgres:11.6
     ports:
       - "5432"
+    volumes:
+      - ./postgres/create-keycloak-db.sql:/docker-entrypoint-initdb.d/create-keycloak-db.sql
 
   redis:
     image: redis:5.0.5
@@ -110,6 +112,26 @@ services:
       - db
       - redis
     profiles: ["notebook"]
+  
+  keycloak:
+      build:
+        context: ./keycloak
+        args:
+          KEYCLOAK_THEME_GIT_REF: ${KEYCLOAK_THEME_GIT_REF:-main}
+      command: start-dev
+      environment:
+        DB_VENDOR: POSTGRES
+        DB_ADDR: db
+        DB_DATABASE: keycloak
+        DB_USER: keycloak
+        DB_SCHEMA: public
+        DB_PASSWORD: keycloak
+        KEYCLOAK_ADMIN: admin
+        KEYCLOAK_ADMIN_PASSWORD: Pa55w0rd
+      ports:
+        - 8080:8080
+      depends_on:
+        - db
 
 volumes:
   django_media: {}

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:latest as theme-installer
+# we have to use alpine here because the keycloak image is extremely stripped down
+
+# Argument to select git ref
+ARG KEYCLOAK_THEME_GIT_REF
+ENV KEYCLOAK_THEME_GIT_REF=${KEYCLOAK_THEME_GIT_REF:-main}
+ENV KEYCLOAK_THEME_TARBALL_URL=https://github.com/mitodl/odl-custom-keycloak/archive/${KEYCLOAK_THEME_GIT_REF}.tar.gz
+
+RUN apk add git
+RUN cd /tmp && wget $KEYCLOAK_THEME_TARBALL_URL -O - | tar -C /tmp -xzf - --strip-components=1
+
+FROM quay.io/keycloak/keycloak:latest as builder
+COPY --from=theme-installer /tmp/themes/ /opt/keycloak/themes/
+
+WORKDIR /opt/keycloak
+RUN /opt/keycloak/bin/kc.sh build
+
+
+# -------------------------------------------------------------------------
+FROM quay.io/keycloak/keycloak:latest
+COPY --from=builder /opt/keycloak /opt/keycloak
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/postgres/create-keycloak-db.sql
+++ b/postgres/create-keycloak-db.sql
@@ -1,0 +1,6 @@
+SELECT 'CREATE DATABASE keycloak'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'keycloak');\gexec
+
+CREATE USER keycloak WITH PASSWORD 'keycloak';
+GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
+GRANT ALL PRIVILEGES ON DATABASE keycloak TO postgres;


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #2 

#### What's this PR do?
This adds a keycloak container to docker-compose that integrates our theme for local testing.

#### How should this be manually tested?
By default it runs off the `main` branch of `mitodl/odl-custom-keycloak`, so you probably want to run this by setting `KEYCLOAK_THEME_GIT_REF=<commit or branch> docker compose build keycloak` if the theme changes haven't been merged yet.

Then login to the admin UI using the admin username/password in `docker-compose.yml` and verify you can enable our theme.